### PR TITLE
Make it work with Firefox/Greasemonkey

### DIFF
--- a/bamboohr-timesheet-month.user.js
+++ b/bamboohr-timesheet-month.user.js
@@ -95,7 +95,7 @@ const DEFAULT_ENTROPY_MINUTES = 10;
         entries.push({
           id: null,
           trackingId: tracking_id,
-          employeeId: SESSION_USER.employeeId,
+          employeeId: unsafeWindow.SESSION_USER.employeeId,
           date: date_str,
           start: `${start.getHours()}:${('0' + start.getMinutes()).slice(-2)}`,
           end: `${end.getHours()}:${('0' + end.getMinutes()).slice(-2)}`,
@@ -111,10 +111,9 @@ const DEFAULT_ENTROPY_MINUTES = 10;
         mode: 'cors',
         cache: 'no-cache',
         credentials: 'same-origin',
-        referrer: 'client',
         headers: {
           'content-type': 'application/json; charset=UTF-8',
-          'x-csrf-token': CSRF_TOKEN
+          'x-csrf-token': unsafeWindow.CSRF_TOKEN
         },
         body: JSON.stringify({ entries: entries })
       }


### PR DESCRIPTION
- unsafeWindow is needed to access the main window when `@grant`s are used
- `referrer: client` broke for some reason. Removed it since it should be the default anyway

This may break Chrome/Tampermonkey horribly, I have not tested it.